### PR TITLE
Exclude script tags from being shown

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -2,7 +2,7 @@ require(["gitbook"], function(gitbook) {
     gitbook.events.bind("page.change", function() {
         $('ul.summary li li').hide();
         // $('ul.summary li').find('li.active').parent().children().show();
-        $('ul.summary li li.active').parents().children().show();
+        $('ul.summary li li.active').parents().children(':not(script)').show();
         $('ul.summary li.active > ul > li').show();        
     });
 });


### PR DESCRIPTION
Some GitBook plugins (like Google Analytics) create `<script>` tags that are included by the children selector. This causes the script tags content to be shown on the page:

![image](https://cloud.githubusercontent.com/assets/5618812/20642312/a091ca04-b3d1-11e6-9017-88a2b4c5d1e4.png)

This pull request excludes those tags from the selector.